### PR TITLE
Execution failed for task ':downloadAllure'.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ allure {
     useTestNG {
         version = allureVersion
     }
-    downloadLink = "http://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/$allureVersion/allure-commandline-$allureVersion.zip"
+    downloadLink = "https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/$allureVersion/allure-commandline-$allureVersion.zip"
 }
 
 dependencies {


### PR DESCRIPTION
Using https fix the problem, because https is no more available when you use maven